### PR TITLE
fix: pin typescript to 6.0.3 in deploy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Container image that runs your code
 FROM node:22-alpine
 
-RUN npm i -g ejs-cli ts-node typescript @cubos/kube-templates @types/node@~24 firebase-tools && npm cache clean --force
+RUN npm i -g ejs-cli ts-node typescript@6.0.3 @cubos/kube-templates @types/node@~24 firebase-tools && npm cache clean --force
 
 RUN apk add --update bash curl
 


### PR DESCRIPTION
## Objetivo do PR:
Desbloquear os deploys que usam a cubos-cli. Hoje, dia 08/07/2026, por volta das 13h, todos passaram a falhar no passo de deploy com o seguinte erro:
```bash
    TypeError: Cannot read properties of undefined (reading 'fileExists')
        at readConfig (ts-node/dist/configuration.js:91)
```

A causa é o TypeScript 7.0.2 que foi publicado no npm nesse dia e virou o `latest`. Como o Dockerfile instala o typescript sem travar a versão (`npm i -g typescript`), a imagem passou a baixar a 7.0.2, cuja API mudou e não é compatível com o `ts-node 10.9.2`. 

## O que mudou:
- Dockerfile:  Adição de versão `typescript@6.0.3`, a última estável antes da 7.0.2